### PR TITLE
Make inFile positional and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ yxd is a hex dump tool similar to xxd, but with features that I wanted. It's wri
 
 ```
 usage: yxd.py [-h] [-f INFILE] [-o STARTOFFSET] [-s BUFFERSIZE] [-r] [--plain] [--xx] [--ps] [--py] [--sc] [--style] [-v]
+              inFile
 
 yxd - Yuu's heX Dumper
 
+positional arguments:
+  inFile          File to open
+  
 optional arguments:
   -h, --help      show this help message and exit
   -f INFILE       File to open

--- a/yxd.py
+++ b/yxd.py
@@ -6,6 +6,7 @@ import yxdconfig as yc
 
 parser = argparse.ArgumentParser(description="yxd - Yuu's heX Dumper")
 parser.add_argument('-f', dest='inFile', help='File to open')
+parser.add_argument('inFile', help='File to open', nargs='?')
 parser.add_argument('-o', type=lambda x: int(x,0), dest='startOffset', help='Offset to start within file')
 parser.add_argument('-s', type=lambda x: int(x,0), dest='bufferSize', help='Size of buffer to dump')
 parser.add_argument('-r', dest='reverseDump', help='Do a reverse hex dump',action="store_true")
@@ -19,7 +20,7 @@ parser.add_argument('-v', dest='printVersion', help='Print Version Info',action=
 
 versionInfo="""
 yxd - Yuu's heX Dumper
-Version 20220925.3
+Version 20230216.0
 """
 
 def styleDump():

--- a/yxd.py
+++ b/yxd.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
     startOffset = args.startOffset if args.startOffset else 0
     blockSize   = 16 
 
-    if args.inFile:
+    if args.inFile and args.inFile != "-":
         inFile = args.inFile
         with open(inFile,"rb") as f:
             f.seek(startOffset)

--- a/yxd.py
+++ b/yxd.py
@@ -6,7 +6,7 @@ import yxdconfig as yc
 
 parser = argparse.ArgumentParser(description="yxd - Yuu's heX Dumper")
 parser.add_argument('-f', dest='inFile', help='File to open')
-parser.add_argument('inFile', help='File to open', nargs='?')
+parser.add_argument('input', help='File to open', nargs='?')
 parser.add_argument('-o', type=lambda x: int(x,0), dest='startOffset', help='Offset to start within file')
 parser.add_argument('-s', type=lambda x: int(x,0), dest='bufferSize', help='Size of buffer to dump')
 parser.add_argument('-r', dest='reverseDump', help='Do a reverse hex dump',action="store_true")
@@ -22,7 +22,6 @@ versionInfo="""
 yxd - Yuu's heX Dumper
 Version 20230216.0
 """
-
 def styleDump():
     for i in range(0,256):
         print(f"{yc.bytez[i]}{i:02X}{yc.EOA} ",end="")
@@ -171,6 +170,10 @@ def reverseDump(inBytes):
 
 if __name__ == '__main__':
     args = parser.parse_args()
+
+    if args.inFile == None:
+        args.inFile = args.input
+
     hexStyle = "yxd"          # Default style
     if args.plainText:
         hexStyle = "xxd"


### PR DESCRIPTION
I've been using yxd for a while now and I've added a few tweaks that I thought would make it nicer, and the syntax to fit with other tools:

- Added another argument to argparse that allows for specifying the input file without `-f`. I find it easier to type and it's more similar in style to other utilities. Files specified with `-f` have precedence`

Now you can do `yxd file.bin` instead of the longer `yxd.py -f file.bin` (my local machine has it installed without .py)

- Added reading from `stdin` if filename is `-` to make it fit the usual syntax 