### PR TITLE
add Autoskip mode

### DIFF
--- a/yxd.py
+++ b/yxd.py
@@ -372,6 +372,7 @@ def main():
     if args.xxFormat:
         hexStyle = "xx"
     if args.psFormat:
+        args.autoSkip = False
         hexStyle = "ps"
 
     bufferSize  = args.bufferSize  if args.bufferSize else 0

--- a/yxd.py
+++ b/yxd.py
@@ -99,6 +99,8 @@ def dump(inBytes,baseAddr=0,dataLen=0,blockSize=16,outFormat="xxd",quiet=False,a
             bAsc = ""
             if autoSkip and lastChunk is not None and all(x == 0 for x in lastChunk):
                 lastChunkAllNulls = True
+            else:
+                lastChunkAllNulls = False
             bChunk = inBytes[offs:offs+blockSize]
             if autoSkip and all(x == 0 for x in bChunk) and len(bChunk) == blockSize:
                 thisChunkAllNulls = True
@@ -128,14 +130,16 @@ def dump(inBytes,baseAddr=0,dataLen=0,blockSize=16,outFormat="xxd",quiet=False,a
             line = makeDumpLine(outFormat, hexOut, offsetOut, bAsc)
             if not autoSkip and not quiet:
                 print(line, end="") # the line comes from makeDumpLine with a newline if it needs one
-            else:
-                if lastChunk is None or not thisChunkAllNulls:
-                    autoSkipped = False
+            elif not quiet:
+                if lastChunk is None:
                     print(line, end="")
-                elif thisChunkAllNulls and lastChunkAllNulls:
+                elif lastChunkAllNulls and thisChunkAllNulls:
                     if not autoSkipped:
                         print("*")
-                        autoSkipped = True
+                    autoSkipped = True
+                else:
+                    autoSkipped = False
+                    print(line, end="")
             hexDumpOut += line
             offs = offs + blockSize
             lastChunk = bChunk

--- a/yxd.py
+++ b/yxd.py
@@ -34,6 +34,17 @@ def styleDump():
             else:
                 print()
 
+def makeDumpLine(outFormat, hexOut, offsetOut, bAsc):
+    """
+    Produce an output line of the given format.
+    """
+    if outFormat == "xx":
+        return f"{hexOut}; {offsetOut}{bAsc}\n"
+    elif outFormat == "ps":
+        return "".join(hexOut.split())
+    else:
+        return f"{offsetOut}{hexOut}{bAsc}\n"
+
 def dump(inBytes,baseAddr=0,dataLen=0,blockSize=16,outFormat="xxd",quiet=False):
     """
     Dump hex.
@@ -103,18 +114,10 @@ def dump(inBytes,baseAddr=0,dataLen=0,blockSize=16,outFormat="xxd",quiet=False):
             hexOut += f"{hb[10]}{hb[11]} "
             hexOut += f"{hb[12]}{hb[13]} "
             hexOut += f"{hb[14]}{hb[15]}{dumpSEP2}"
-            if outFormat == "xx":
-                if quiet == False:
-                    print(f"{hexOut}; {offsetOut}{bAsc}")
-                hexDumpOut += f"{hexOut}; {offsetOut}{bAsc}\n"
-            elif outFormat == "ps":
-                if quiet == False:
-                    print("".join(hexOut.split()),end="")
-                hexDumpOut += "".join(hexOut.split())
-            else:
-                if quiet == False:
-                    print(f"{offsetOut}{hexOut}{bAsc}")
-                hexDumpOut += f"{offsetOut}{hexOut}{bAsc}\n"
+            line = makeDumpLine(outFormat, hexOut, offsetOut, bAsc)
+            if not quiet:
+                print(line, end="") # the line comes from makeDumpLine with a newline if it needs one
+            hexDumpOut += line
             offs = offs + blockSize
         except Exception as e:
             print(f"yxd.dump: {e}")

--- a/yxd.py
+++ b/yxd.py
@@ -19,7 +19,7 @@ parser.add_argument('--sc', help='Create a C shellcode loader from buffer', dest
 parser.add_argument('--style', help='Show Current Hex Style', dest='dumpStyle', action="store_true")
 parser.add_argument('-v', help='Print Version Info', dest='printVersion', action="store_true")
 
-versionInfo="yxd - Yuu's heX Dumper Version 20230831.0"""
+versionInfo="yxd - Yuu's heX Dumper Version 20230831.0"
 
 def styleDump():
     """
@@ -76,7 +76,7 @@ def dump(inBytes,baseAddr=0,dataLen=0,blockSize=16,outFormat="xxd",quiet=False,a
     """
     dataLen = len(inBytes) if ( dataLen == 0 ) or ( dataLen > len(inBytes) ) else dataLen # Sanity check
     offs = 0
-    hexDumpOut = "" 
+    hexDumpOut = ""
     # Style
     dumpBytez = yc.bytez
     dumpOffstyle = yc.OFFSTYLE


### PR DESCRIPTION
this cleans up the logic for generating individual dump lines, at the cost of complicating the main dump loop to implement autoskip mode. Presently it does not handle "the very last line is also nulls" in the same way that `xxd` does, but it works well enough for our purposes:

```
atax1a@tecpatl:~/package/yxd π PYTHONPATH=. python3 yxd.py -a /tmp/b
00000000│0000 0000 0000 0000│0000 0000 0000 0000│................
*
atax1a@tecpatl:~/package/yxd π xxd -a /tmp/b
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
*
000001f0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
```
